### PR TITLE
Avoid failing on erroneous lines.

### DIFF
--- a/tools/generate.py
+++ b/tools/generate.py
@@ -134,11 +134,17 @@ def generate_n_grams():
         'r',
         encoding='utf-8'
     )
+    lineNumber = 0
     for line in input:
-        cols = line[:-1].split("\t")
-        lang = cols[1]
-        text = cols[2]
-        user = cols[3]
+        lineNumber += 1
+        try:
+            cols = line[:-1].split("\t")
+            lang = cols[1]
+            text = cols[2]
+            user = cols[3]
+        except IndexError:
+            print(u'Skipped erroneous line {}: {}'.format(lineNumber, line))
+            continue
 
         # we ignore the sentence with an unset language
         if lang == '\\N' or lang == '':


### PR DESCRIPTION
Trial-and-error is painful when testing takes time. Since the proccess of
generating the n-grams database is long and ressources-consuming, it’s
better not stop in the middle just because of one or two malformed lines.
This allows the user to get a complete list of erroneous lines, fix them
all at once and run the script again.
